### PR TITLE
Fixed error with path names having leading slashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ SuperAwesomeWebpackPlugin.prototype.apply = function(compiler) {
                         const routes = rootRoute(siteFixed.component, siteFixed.routes, siteFixed.index)
 
                         dataFiles.map((dataFile) => {
-                            let fileRoute = dataFile.replace(dataDir.replace('./', ''), '').replace('.json', '');
+                            let fileRoute = dataFile.replace(dataDir.replace(/^(\.\/|\/)/, ''), '').replace('.json', '');
                             const state = require(path.resolve(dataFile));
                             let appRoute = generateAppRoute(dataFile, dataDir);
 


### PR DESCRIPTION
Assets will not be recognized by webpack-dev-server if they have leading slashes.

`/folder/asset.js -> folder/asset.js`